### PR TITLE
fix 64-bit issue

### DIFF
--- a/lib/ApkXmlParser.php
+++ b/lib/ApkXmlParser.php
@@ -84,7 +84,7 @@
                             $off += 5*4;
 
                             $attrName = $this->compXmlString($this->bytes, $sitOff, $stOff, $attrNameSi);
-                            if($attrValueSi != -1)
+                            if($attrValueSi != 0xffffffff)
                                 $attrValue =  $this->compXmlString($this->bytes, $sitOff, $stOff, $attrValueSi);
                             else
                                 $attrValue  = "0x" . dechex($attrResId);


### PR DESCRIPTION
On 64-bit machines -1 != 0xffffffff, changing -1 to 0xffffffff fixed the issue. See also issue #6.
