### PR TITLE
some manifest.xml has non-ascii characters 

### DIFF
--- a/lib/ApkParser/XmlParser.php
+++ b/lib/ApkParser/XmlParser.php
@@ -202,7 +202,9 @@ class XmlParser
     {
         if (!$this->ready)
             $this->decompress();
-        return $this->xml;
+        $xml = urlencode($this->xml);
+        $xml = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', '', $xml);
+        return $xml;
     }
 
     public function getXmlObject($className = '\SimpleXmlElement')


### PR DESCRIPTION
Which won't be accepted by simplexml_load_string and caused error. Striping them to make the parser work well.