### PR TITLE
APK resources returns null due to config change in 1282c68

### DIFF
--- a/examples/ApkResource.php
+++ b/examples/ApkResource.php
@@ -10,7 +10,7 @@
  */
 
 include 'autoload.php';
-$apk = new \ApkParser\Parser('vitrinova.apk');
+$apk = new \ApkParser\Parser('vitrinova.apk', ['manifest_only' => false]);
 $resourceId = $apk->getManifest()->getApplication()->getIcon();
 $resources = $apk->getResources($resourceId);
 


### PR DESCRIPTION
Need to pass the config ['manifest_only' => false], in order to get the APK resources. Else getResources() will return null.