### PR TITLE
fix: escape xml attribute value when it has special html characters

### DIFF
--- a/lib/ApkParser/XmlParser.php
+++ b/lib/ApkParser/XmlParser.php
@@ -174,7 +174,7 @@ class XmlParser
                                 $attrValue = "0x" . dechex($attrResId);
                             }
 
-                            $attr_string .= " " . $attrName . "=\"" . $attrValue . "\"";
+                            $attr_string .= " " . $attrName . "=\"" . htmlspecialchars($attrValue) . "\"";
                         }
 
                         $this->appendXmlIndent($indentCount, "<" . $tagName . $attr_string . ">");


### PR DESCRIPTION
There are sometimes XML element that has values with quotes etc.

Example - 

```
<meta-data name="icons" value="[{&quot;src&quot;:&quot;icon_512.png&quot;,&quot;sizes&quot;:&quot;512x512&quot;,&quot;type&quot;:&quot;image/png&quot;,&quot;purpose&quot;:&quot;any maskable&quot;}]">
```
The `decompress()` method inside the `XmlParser` class outputs this XML element with quotes which makes the XML invalid.


decompress() output

```
<meta-data name="icons" value="[{"src":"icons_512.png","sizes":"512x512","type":"image/png","purpose":"any maskable"}]">
```

This PR adds the feature to convert these special characters so that the XML is valid.

decompress() new output

```
<meta-data name="icons" value="[{&quot;src&quot;:&quot;icons_512.png&quot;,&quot;sizes&quot;:&quot;512x512&quot;,&quot;type&quot;:&quot;image/png&quot;,&quot;purpose&quot;:&quot;any maskable&quot;}]">
```