### PR TITLE
Support getResources() lookup by symbolic resource key

### DIFF
--- a/test/ResourcesParserTest.php
+++ b/test/ResourcesParserTest.php
@@ -77,6 +77,14 @@ class ResourcesParserTest extends \PHPUnit\Framework\TestCase
                 $fixture['expected_values'],
                 $resourcesParser->getResources($fixture['expected_resource_id'])
             );
+            $this->assertSame(
+                $fixture['expected_values'],
+                $resourcesParser->getResources('@' . $fixture['type_name'] . '/' . $fixture['key_name'])
+            );
+            $this->assertSame(
+                $fixture['expected_values'],
+                $resourcesParser->getResources($fixture['type_name'] . '/' . $fixture['key_name'])
+            );
         } finally {
             if ($archive instanceof Archive) {
                 $archive->close();


### PR DESCRIPTION
## Summary
- add resource name indexing in `ResourcesParser` so lookups work with `@type/name` and `type/name`
- keep existing numeric id lookups unchanged
- add fixture-based coverage to validate id and symbolic key lookups resolve to the same values

## Verification
- `make docker-test`

Fixes #89
